### PR TITLE
Disable ASM for tremolo since it may crashes while decoding same specific ogg audio files.

### DIFF
--- a/sources/tremolo/Android.mk
+++ b/sources/tremolo/Android.mk
@@ -16,21 +16,22 @@ LOCAL_SRC_FILES = \
 	Tremolo/treminfo.c \
 	Tremolo/vorbisfile.c
 
-ifeq ($(TARGET_ARCH),arm)
-LOCAL_SRC_FILES += \
-	Tremolo/bitwiseARM.s \
-	Tremolo/dpen.s \
-	Tremolo/floor1ARM.s \
-	Tremolo/mdctARM.s
-LOCAL_CFLAGS += \
-    -D_ARM_ASSEM_
-# Assembly code in asm_arm.h does not compile with Clang.
-LOCAL_CLANG_ASFLAGS_arm += \
-    -no-integrated-as
-else
+# Disable arm optimization which will cause the issue https://github.com/cocos2d/cocos2d-x/issues/17148
+# ifeq ($(TARGET_ARCH),arm)
+# LOCAL_SRC_FILES += \
+# 	Tremolo/bitwiseARM.s \
+# 	Tremolo/dpen.s \
+# 	Tremolo/floor1ARM.s \
+# 	Tremolo/mdctARM.s
+# LOCAL_CFLAGS += \
+#     -D_ARM_ASSEM_
+# # Assembly code in asm_arm.h does not compile with Clang.
+# LOCAL_CLANG_ASFLAGS_arm += \
+#     -no-integrated-as
+# else
 LOCAL_CFLAGS += \
     -DONLY_C
-endif
+# endif
 LOCAL_CFLAGS+= -O2
 
 LOCAL_C_INCLUDES:= \


### PR DESCRIPTION
The performance result of enabling or disabling ASM in tremolo library is the almost same.
It indicates that C compiler has make a lot optimizations in C code.
What's more, ASM code may trigger crash while decoding some specific ogg files.