### PR TITLE
revert link order adjustment

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -105,7 +105,7 @@ endif()
 
 ############################# glslang #############################
 
-set(glslang_libs_name glslang glslang-default-resource-limits SPIRV MachineIndependent OGLCompiler OSDependent SPIRV-Tools-opt SPIRV-Tools GenericCodeGen)
+set(glslang_libs_name glslang glslang-default-resource-limits MachineIndependent OGLCompiler OSDependent SPIRV SPIRV-Tools-opt SPIRV-Tools GenericCodeGen)
 foreach(lib IN LISTS glslang_libs_name)
   add_library(${lib} STATIC IMPORTED GLOBAL)
   set_target_properties(${lib} PROPERTIES

--- a/win32/CMakeLists.txt
+++ b/win32/CMakeLists.txt
@@ -200,7 +200,7 @@ endif()
 
 ############################# glslang #############################
 
-set(glslang_libs_name glslang glslang-default-resource-limits SPIRV MachineIndependent OGLCompiler OSDependent SPIRV-Tools-opt SPIRV-Tools GenericCodeGen)
+set(glslang_libs_name glslang glslang-default-resource-limits MachineIndependent OGLCompiler OSDependent SPIRV SPIRV-Tools-opt SPIRV-Tools GenericCodeGen)
 foreach(gl IN LISTS glslang_libs_name)
   add_library(${gl} STATIC IMPORTED GLOBAL)
   set_target_properties(${gl} PROPERTIES

--- a/win64/CMakeLists.txt
+++ b/win64/CMakeLists.txt
@@ -200,7 +200,7 @@ endif()
 
 ############################# glslang #############################
 
-set(glslang_libs_name glslang glslang-default-resource-limits SPIRV MachineIndependent OGLCompiler OSDependent SPIRV-Tools-opt SPIRV-Tools GenericCodeGen)
+set(glslang_libs_name glslang glslang-default-resource-limits MachineIndependent OGLCompiler OSDependent SPIRV SPIRV-Tools-opt SPIRV-Tools GenericCodeGen)
 foreach(gl IN LISTS glslang_libs_name)
   add_library(${gl} STATIC IMPORTED GLOBAL)
   set_target_properties(${gl} PROPERTIES


### PR DESCRIPTION
The new order will lead to compilation failures when running 32-bit app
on 64-bit devices. /eyerolling