### PR TITLE
adapt editor native scene

### DIFF
--- a/win64/CMakeLists.txt
+++ b/win64/CMakeLists.txt
@@ -194,7 +194,7 @@ if(USE_SE_V8)
     )
 
     set(se_libs_name v8)
-else()
+elseif(NOT CC_EDITOR)
    message(FATAL_ERROR "Only V8 is supported!")
 endif()
 


### PR DESCRIPTION
编辑器原生化编译引擎时使用了nodejs提供的v8，需要把这里的报错屏蔽掉